### PR TITLE
Ethermint 관련 주소 방식 변경 후 AuthAPI 에서 accountInfo 함수로 데이타 못 받아오는 부분 수정

### DIFF
--- a/src/core/auth/Account.ts
+++ b/src/core/auth/Account.ts
@@ -1,5 +1,6 @@
 import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
 import { BaseAccount } from './BaseAccount';
+//import { EthAccount } from './EthAccount';
 import { LazyGradedVestingAccount } from './LazyGradedVestingAccount';
 import { ContinuousVestingAccount } from './ContinuousVestingAccount';
 import { DelayedVestingAccount } from './DelayedVestingAccount';
@@ -58,7 +59,13 @@ export namespace Account {
   export function fromData(data: Account.Data, isClassic?: boolean): Account {
     switch (data['@type']) {
       case '/cosmos.auth.v1beta1.BaseAccount':
+      case '/ethermint.types.v1.EthAccount': {
+        if (Object.keys(data).includes('base_account')) {
+          const ba = (data as any).base_account;
+          return BaseAccount.fromData(ba, isClassic);
+        }
         return BaseAccount.fromData(data, isClassic);
+      }
       case '/cosmos.vesting.v1beta1.BaseVestingAccount':
         return BaseVestingAccount.fromData(data, isClassic);
       case '/terra.vesting.v1beta1.LazyGradedVestingAccount':

--- a/src/core/auth/BaseAccount.ts
+++ b/src/core/auth/BaseAccount.ts
@@ -156,7 +156,9 @@ export namespace BaseAccount {
   }
 
   export interface Data extends DataValue {
-    '@type': '/cosmos.auth.v1beta1.BaseAccount';
+    '@type':
+      | '/cosmos.auth.v1beta1.BaseAccount'
+      | '/ethermint.types.v1.EthAccount';
   }
 
   export type Proto = BaseAccount_pb;


### PR DESCRIPTION
Ethermint 관련 주소 방식 변경 후 @type 에 ' /ethermint.types.v1.EthAccount' 타입이 없어서  Account 에 accountInfo 함수로 데이타 못 받아오는 부분 최소 수정. (Account.ts, BaseAccount.ts 2개 파일 수정)
- Amino, Proto 부분은 수정하지 않았습니다.