### PR TITLE
fix: msg update contract admin

### DIFF
--- a/src/core/Msg.ts
+++ b/src/core/Msg.ts
@@ -932,7 +932,7 @@ export namespace Msg {
         return MsgInstantiateContractV1.unpackAny(proto, isClassic);
       case '/cosmwasm.wasm.v1.MsgExecuteContract':
         return MsgExecuteContractV1.unpackAny(proto, isClassic);
-      case '/cosmwasm.wasm.v1beta1.MsgMigrateContract':
+      case '/cosmwasm.wasm.v1.MsgMigrateContract':
         return MsgMigrateContractV1.unpackAny(proto, isClassic);
       case '/cosmwasm.wasm.v1.MsgUpdateAdmin':
         return MsgUpdateContractAdminV1.unpackAny(proto, isClassic);

--- a/src/core/Msg.ts
+++ b/src/core/Msg.ts
@@ -934,7 +934,7 @@ export namespace Msg {
         return MsgExecuteContractV1.unpackAny(proto, isClassic);
       case '/cosmwasm.wasm.v1beta1.MsgMigrateContract':
         return MsgMigrateContractV1.unpackAny(proto, isClassic);
-      case '/cosmwasm.wasm.v1beta1.MsgUpdateAdmin':
+      case '/cosmwasm.wasm.v1.MsgUpdateAdmin':
         return MsgUpdateContractAdminV1.unpackAny(proto, isClassic);
       case '/cosmwasm.wasm.v1.MsgClearAdmin':
         return MsgClearContractAdminV1.unpackAny(proto, isClassic);


### PR DESCRIPTION
Error in decode due to missing MsgUpdateContractAdminV1 in fromProto. I change the message to the case to fix this issue. 
(https://github.com/xpladev/xpla.js/issues/29)