### PR TITLE
feat: patch to v1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpla/xpla.js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The JavaScript SDK for Xpla",
   "license": "MIT",
   "author": "XPLA",

--- a/src/client/lcd/api/BankAPI.ts
+++ b/src/client/lcd/api/BankAPI.ts
@@ -42,7 +42,7 @@ export class BankAPI extends BaseAPI {
       .get<{
         balances: Coins.Data;
         pagination: Pagination;
-      }>(`/cosmos/bank/v1beta1/balances/${address}/`, params)
+      }>(`/cosmos/bank/v1beta1/balances/${address}`, params)
       .then(d => [Coins.fromData(d.balances), d.pagination]);
   }
 

--- a/src/client/lcd/api/BankAPI.ts
+++ b/src/client/lcd/api/BankAPI.ts
@@ -1,7 +1,29 @@
 import { BaseAPI } from './BaseAPI';
-import { Coins, AccAddress, BankParamsV1B1 } from '../../../core';
+import { Coin, Coins, AccAddress, BankParamsV1B1 } from '../../../core';
 import { APIParams, Pagination, PaginationOptions } from '../APIRequester';
 import { LCDClient } from '../LCDClient';
+
+export interface DenomOwner {
+  address: AccAddress;
+  balance: Coin;
+}
+
+export interface DenomUnit {
+  denom: string;
+  exponent: number;
+  aliases: string[];
+}
+
+export interface DenomMetadata {
+  description: string;
+  denom_units: DenomUnit[];
+  base: string;
+  display: string;
+  name: string;
+  symbol: string;
+  uri: string | undefined;
+  uri_hash: string | undefined;
+}
 
 export class BankAPI extends BaseAPI {
   constructor(public lcd: LCDClient) {
@@ -20,8 +42,56 @@ export class BankAPI extends BaseAPI {
       .get<{
         balances: Coins.Data;
         pagination: Pagination;
-      }>(`/cosmos/bank/v1beta1/balances/${address}`, params)
+      }>(`/cosmos/bank/v1beta1/balances/${address}/`, params)
       .then(d => [Coins.fromData(d.balances), d.pagination]);
+  }
+
+  /**
+   * Look up the balance of an account by its address.
+   * @param address address of account to look up.
+   * @param denom denom to look up.
+   */
+  public async balanceByDenom(
+    address: AccAddress,
+    denom: string,
+    params: Partial<PaginationOptions & APIParams> = {}
+  ): Promise<Coin> {
+    return this.c
+      .get<{
+        balance: Coin.Data;
+      }>(`/cosmos/bank/v1beta1/balances/${address}/by_denom`, {denom, ...params})
+      .then(d => Coin.fromData(d.balance));
+  }
+
+  /**
+   * Look up the balance of an account by its address.
+   * @param denom denom to look up.
+   */
+  public async denomOwners(
+    denom: string,
+    params: Partial<PaginationOptions & APIParams> = {}
+  ): Promise<[DenomOwner[], Pagination]> {
+    return this.c
+      .get<{
+        denom_owners: DenomOwner[];
+        pagination: Pagination;
+      }>(`/cosmos/bank/v1beta1/denom_owners/${denom}`, params)
+      .then(d => [d.denom_owners, d.pagination]);
+  }
+
+  /**
+   * Look up the balance of an account by its address.
+   * @param denom denom to look up.
+   */
+  public async denomsMetadata(
+    params: Partial<PaginationOptions & APIParams> = {}
+  ): Promise<[DenomMetadata[], Pagination]> {
+    return this.c
+      .get<{
+        metadatas: DenomMetadata[];
+        pagination: Pagination;
+      }>(`/cosmos/bank/v1beta1/denoms_metadata`, params)
+      .then(d => [d.metadatas, d.pagination]);
   }
 
   /**

--- a/src/client/lcd/api/FeemarketAPI.ts
+++ b/src/client/lcd/api/FeemarketAPI.ts
@@ -1,0 +1,21 @@
+import { FeemarketParamsV1 } from '../../../core';
+import { APIParams } from '../APIRequester';
+import { LCDClient } from '../LCDClient';
+import { BaseAPI } from './BaseAPI';
+
+export class FeemarketAPI extends BaseAPI {
+  constructor(public lcd: LCDClient) {
+    super(lcd.apiRequester);
+  }
+
+  /**
+   * Gets the current ethermint feemarket module's parameters.
+   */
+  public async parameters(
+    params: APIParams = {}
+  ): Promise<FeemarketParamsV1 | any> {
+    return this.c
+      .get<{ params: any }>('/ethermint/feemarket/v1/params', params)
+      .then(({ params: d }) => FeemarketParamsV1.fromData(d));
+  }
+}

--- a/src/client/lcd/api/StakingAPI.ts
+++ b/src/client/lcd/api/StakingAPI.ts
@@ -284,7 +284,7 @@ export class StakingAPI extends BaseAPI {
   public async parameters(params: APIParams = {}): Promise<StakingParams> {
     return this.c
       .get<{ params: StakingParams.Data }>(
-        `/cosmos/staking/v1beta1/params`,
+        '/cosmos/staking/v1beta1/params',
         params
       )
       .then(({ params: d }) => ({

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -371,7 +371,7 @@ export class TxAPI extends BaseAPI {
   ): Promise<Fee> {
     const gasPrices = options.gasPrices ?? this.lcd.config.gasPrices;
     const gasAdjustment =
-      options.gasAdjustment ?? this.lcd.config.gasAdjustment ?? 5;
+      options.gasAdjustment ?? this.lcd.config.gasAdjustment ?? 2.0;
     const feeDenoms = options.feeDenoms ?? [
       this.lcd.config.isClassic ? 'uusd' : 'axpla',
     ];
@@ -427,7 +427,7 @@ export class TxAPI extends BaseAPI {
     }
   ): Promise<number> {
     const gasAdjustment =
-      options?.gasAdjustment ?? this.lcd.config.gasAdjustment ?? 5;
+      options?.gasAdjustment ?? this.lcd.config.gasAdjustment ?? 2.0;
 
     // append empty signatures if there's no signatures in tx
     let simTx: Tx = tx;
@@ -446,7 +446,7 @@ export class TxAPI extends BaseAPI {
       })
       .then(d => SimulateResponse.fromData(d));
 
-    return new Dec(gasAdjustment).mul(simulateRes.gas_info.gas_used).toDecimalPlaces(0, Dec.ROUND_UP).toNumber();
+    return Math.ceil(parseFloat(gasAdjustment.toString()) * simulateRes.gas_info.gas_used);
   }
 
   public async computeTax(): Promise<Coins> {

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -371,7 +371,7 @@ export class TxAPI extends BaseAPI {
   ): Promise<Fee> {
     const gasPrices = options.gasPrices ?? this.lcd.config.gasPrices;
     const gasAdjustment =
-      options.gasAdjustment ?? this.lcd.config.gasAdjustment;
+      options.gasAdjustment ?? this.lcd.config.gasAdjustment ?? 5;
     const feeDenoms = options.feeDenoms ?? [
       this.lcd.config.isClassic ? 'uusd' : 'axpla',
     ];
@@ -427,7 +427,7 @@ export class TxAPI extends BaseAPI {
     }
   ): Promise<number> {
     const gasAdjustment =
-      options?.gasAdjustment ?? this.lcd.config.gasAdjustment;
+      options?.gasAdjustment ?? this.lcd.config.gasAdjustment ?? 5;
 
     // append empty signatures if there's no signatures in tx
     let simTx: Tx = tx;
@@ -446,7 +446,7 @@ export class TxAPI extends BaseAPI {
       })
       .then(d => SimulateResponse.fromData(d));
 
-    return new Dec(gasAdjustment).mul(simulateRes.gas_info.gas_used).toNumber();
+    return new Dec(gasAdjustment).mul(simulateRes.gas_info.gas_used).toDecimalPlaces(0, Dec.ROUND_UP).toNumber();
   }
 
   public async computeTax(): Promise<Coins> {

--- a/src/client/lcd/api/index.ts
+++ b/src/client/lcd/api/index.ts
@@ -6,6 +6,7 @@ export * from './DistributionAPI';
 export * from './ERC20API';
 export * from './EvmAPI';
 export * from './FeeGrantAPI';
+export * from './FeemarketAPI';
 export * from './GovAPI';
 export * from './MintAPI';
 export * from './SlashingAPI';

--- a/src/core/Msg.ts
+++ b/src/core/Msg.ts
@@ -28,6 +28,7 @@ import {
   MsgGrantAllowance,
   MsgRevokeAllowance,
 } from './feegrant/msgs';
+import { FeemarketMsgV1, MsgUpdateFeemarketParamsV1 } from './feemarket';
 import {
   GovMsgV1,
   MsgDepositV1B1,
@@ -155,6 +156,7 @@ export type Msg =
   | ConsensusMsgV1B1
   | DistributionMsgV1B1
   | FeeGrantMsg
+  | FeemarketMsgV1
   | GovMsgV1B1
   | GovMsgV1
   | GroupMsgV1
@@ -182,6 +184,7 @@ export namespace Msg {
     | ConsensusMsgV1B1.Amino
     | DistributionMsgV1B1.Amino
     | FeeGrantMsg.Amino
+    | FeemarketMsgV1.Amino
     | GovMsgV1B1.Amino
     | GovMsgV1.Amino
     | GroupMsgV1.Amino
@@ -205,6 +208,7 @@ export namespace Msg {
     | ConsensusMsgV1B1.Data
     | DistributionMsgV1B1.Data
     | FeeGrantMsg.Data
+    | FeemarketMsgV1.Data
     | GovMsgV1B1.Data
     | GovMsgV1.Data
     | GroupMsgV1.Data
@@ -231,6 +235,7 @@ export namespace Msg {
     | ConsensusMsgV1B1.Proto
     | DistributionMsgV1B1.Proto
     | FeeGrantMsg.Proto
+    | FeemarketMsgV1.Proto
     | GovMsgV1B1.Proto
     | GovMsgV1.Proto
     | GroupMsgV1.Proto
@@ -308,6 +313,10 @@ export namespace Msg {
       case 'feegrant/MsgRevokeAllowance':
       case 'cosmos-sdk/MsgRevokeAllowance':
         return MsgRevokeAllowance.fromAmino(data, isClassic);
+
+      // feemarket
+      case 'feemarket/MsgUpdateParams':
+        return MsgUpdateFeemarketParamsV1.fromAmino(data, isClassic);
 
       // gov
       case 'gov/MsgDeposit':
@@ -569,6 +578,10 @@ export namespace Msg {
       case '/cosmos.feegrant.v1beta1.MsgRevokeAllowance':
         return MsgRevokeAllowance.fromData(data, isClassic);
 
+      // feemarket
+      case '/ethermint.feemarket.v1.MsgUpdateParams':
+        return MsgUpdateFeemarketParamsV1.fromData(data, isClassic);
+
       // gov
       case '/cosmos.gov.v1beta1.MsgDeposit':
         return MsgDepositV1B1.fromData(data, isClassic);
@@ -820,6 +833,10 @@ export namespace Msg {
         return MsgGrantAllowance.unpackAny(proto, isClassic);
       case '/cosmos.feegrant.v1beta1.MsgRevokeAllowance':
         return MsgRevokeAllowance.unpackAny(proto, isClassic);
+
+      // feemarket
+      case '/ethermint.feemarket.v1.MsgUpdateParams':
+        return MsgUpdateFeemarketParamsV1.unpackAny(proto, isClassic);
 
       // gov
       case '/cosmos.gov.v1beta1.MsgDeposit':

--- a/src/core/distribution/v1beta1/Params.ts
+++ b/src/core/distribution/v1beta1/Params.ts
@@ -107,10 +107,11 @@ export class DistributionParamsV1B1 extends JSONSerializable<
     proto: DistributionParamsV1B1.Proto,
     _?: boolean
   ): DistributionParamsV1B1 {
+    const dec18 = new Dec(10).pow(18);
     return new DistributionParamsV1B1(
-      proto.communityTax,
-      proto.baseProposerReward,
-      proto.bonusProposerReward,
+      new Dec(proto.communityTax).div(dec18),
+      new Dec(proto.baseProposerReward).div(dec18),
+      new Dec(proto.bonusProposerReward).div(dec18),
       proto.withdrawAddrEnabled
     );
   }
@@ -122,10 +123,11 @@ export class DistributionParamsV1B1 extends JSONSerializable<
       bonus_proposer_reward,
       withdraw_addr_enabled,
     } = this;
+    const dec18 = new Dec(10).pow(18);
     return DistributionParamsV1B1_pb.fromPartial({
-      communityTax: community_tax.toFixed(),
-      baseProposerReward: base_proposer_reward.toFixed(),
-      bonusProposerReward: bonus_proposer_reward.toFixed(),
+      communityTax: community_tax.mul(dec18).toFixed(0),
+      baseProposerReward: base_proposer_reward.mul(dec18).toFixed(0),
+      bonusProposerReward: bonus_proposer_reward.mul(dec18).toFixed(0),
       withdrawAddrEnabled: withdraw_addr_enabled,
     });
   }

--- a/src/core/feemarket/index.ts
+++ b/src/core/feemarket/index.ts
@@ -1,0 +1,16 @@
+import { FeemarketMsgV1 } from './v1/msgs';
+
+export * from './v1/msgs';
+export * from './v1/Params';
+
+export type FeemarketMsg = FeemarketMsgV1;
+
+export namespace FeemarketMsg {
+  export type Amino = FeemarketMsgV1.Amino;
+  export type Data = FeemarketMsgV1.Data;
+  export type Proto = FeemarketMsgV1.Proto;
+}
+
+export {
+  MsgUpdateFeemarketParamsV1 as MsgUpdateFeemarketParams,
+} from './v1/msgs';

--- a/src/core/feemarket/v1/Params.ts
+++ b/src/core/feemarket/v1/Params.ts
@@ -1,0 +1,193 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { JSONSerializable } from '../../../util/json';
+import { Int, Dec, Numeric } from '../../numeric';
+import {
+  Params as FeemarketParamsV1_pb,
+} from '@xpla/xpla.proto/ethermint/feemarket/v1/feemarket';
+
+export class FeemarketParamsV1 extends JSONSerializable<
+  FeemarketParamsV1.Amino,
+  FeemarketParamsV1.Data,
+  FeemarketParamsV1.Proto
+> {
+  public enable_height: Int;
+  public base_fee: Int;
+  public min_gas_price: Dec;
+  public min_gas_multiplier: Dec;
+
+  /**
+   * @param no_base_fee forces the EIP-1559 base fee to 0 (needed for 0 price calls)
+   * @param base_fee_change_denominator bounds the amount the base fee can change between blocks.
+   * @param elasticity_multiplier bounds the maximum gas limit an EIP-1559 block may have.
+   * @param enable_height defines at which block height the base fee calculation is enabled.
+   * @param base_fee for EIP-1559 blocks.
+   * @param min_gas_price defines the minimum gas price value for cosmos and eth transactions
+   * @param min_gas_multiplier bounds the minimum gas used to be charged to senders based on gas limit
+   */
+  constructor(
+    public no_base_fee: boolean,
+    public base_fee_change_denominator: number,
+    public elasticity_multiplier: number,
+    enable_height: Numeric.Input,
+    base_fee: Numeric.Input,
+    min_gas_price: Numeric.Input,
+    min_gas_multiplier: Numeric.Input,
+  ) {
+    super();
+    this.enable_height = new Int(enable_height);
+    this.base_fee = new Int(base_fee);
+    this.min_gas_price = new Dec(min_gas_price);
+    this.min_gas_multiplier = new Dec(min_gas_multiplier);
+  }
+
+  public static fromAmino(data: FeemarketParamsV1.Amino, _?: boolean): FeemarketParamsV1 {
+    const {
+      no_base_fee,
+      base_fee_change_denominator,
+      elasticity_multiplier,
+      enable_height,
+      base_fee,
+      min_gas_price,
+      min_gas_multiplier,
+    } = data;
+    return new FeemarketParamsV1(
+      no_base_fee ?? false,
+      base_fee_change_denominator ?? 1,
+      elasticity_multiplier ?? 1,
+      enable_height ?? 0,
+      base_fee ?? 0,
+      min_gas_price ?? 0,
+      min_gas_multiplier ?? 0.0,
+    );
+  }
+
+  public toAmino(_?: boolean): FeemarketParamsV1.Amino {
+    const {
+      no_base_fee,
+      base_fee_change_denominator,
+      elasticity_multiplier,
+      enable_height,
+      base_fee,
+      min_gas_price,
+      min_gas_multiplier,
+    } = this;
+
+    const res: FeemarketParamsV1.Amino = {
+      no_base_fee,
+      base_fee_change_denominator,
+      elasticity_multiplier,
+      enable_height: enable_height.toFixed(0),
+      base_fee: base_fee.toFixed(0),
+      min_gas_price: min_gas_price.toFixed(18),
+      min_gas_multiplier: min_gas_multiplier.toFixed(18),
+    };
+
+    return res;
+  }
+
+  public static fromData(data: FeemarketParamsV1.Data, _?: boolean): FeemarketParamsV1 {
+    const {
+      no_base_fee,
+      base_fee_change_denominator,
+      elasticity_multiplier,
+      enable_height,
+      base_fee,
+      min_gas_price,
+      min_gas_multiplier,
+    } = data;
+    return new FeemarketParamsV1(
+      no_base_fee,
+      base_fee_change_denominator,
+      elasticity_multiplier,
+      enable_height,
+      base_fee,
+      min_gas_price,
+      min_gas_multiplier,
+    );
+  }
+
+  public toData(_?: boolean): FeemarketParamsV1.Data {
+    const {
+      no_base_fee,
+      base_fee_change_denominator,
+      elasticity_multiplier,
+      enable_height,
+      base_fee,
+      min_gas_price,
+      min_gas_multiplier,
+    } = this;
+
+    const res: FeemarketParamsV1.Data = {
+      '@type': '/ethermint.feemarket.v1.Params',
+      no_base_fee,
+      base_fee_change_denominator,
+      elasticity_multiplier,
+      enable_height: enable_height.toFixed(0),
+      base_fee: base_fee.toFixed(0),
+      min_gas_price: min_gas_price.toFixed(18),
+      min_gas_multiplier: min_gas_multiplier.toFixed(18),
+    };
+
+    return res;
+  }
+
+  public static fromProto(proto: FeemarketParamsV1.Proto, _?: boolean): FeemarketParamsV1 {
+    const dec18 = new Dec(10).pow(18);
+    return new FeemarketParamsV1(
+      proto.noBaseFee,
+      proto.baseFeeChangeDenominator,
+      proto.elasticityMultiplier,
+      proto.enableHeight.toString(),
+      proto.baseFee,
+      new Dec(proto.minGasPrice).div(dec18), // for cosmos-sdk/types.Dec type
+      new Dec(proto.minGasMultiplier).div(dec18), // for cosmos-sdk/types.Dec type
+    );
+  }
+
+  public toProto(_?: boolean): FeemarketParamsV1.Proto {
+    const {
+      no_base_fee,
+      base_fee_change_denominator,
+      elasticity_multiplier,
+      enable_height,
+      base_fee,
+      min_gas_price,
+      min_gas_multiplier,
+    } = this;
+    const dec18 = new Dec(10).pow(18);
+    return FeemarketParamsV1_pb.fromPartial({
+      noBaseFee: no_base_fee,
+      baseFeeChangeDenominator: base_fee_change_denominator,
+      elasticityMultiplier: elasticity_multiplier,
+      enableHeight: enable_height.toFixed(0),
+      baseFee: base_fee.toFixed(0),
+      minGasPrice: min_gas_price.mul(dec18).toFixed(0), // for cosmos-sdk/types.Dec type
+      minGasMultiplier: min_gas_multiplier.mul(dec18).toFixed(0), // for cosmos-sdk/types.Dec type
+    });
+  }
+}
+
+export namespace FeemarketParamsV1 {
+  export interface Amino {
+    no_base_fee: boolean | undefined;
+    base_fee_change_denominator: number | undefined;
+    elasticity_multiplier: number | undefined;
+    enable_height: string | undefined;
+    base_fee: string | undefined;
+    min_gas_price: string | undefined;
+    min_gas_multiplier: string | undefined;
+  }
+
+  export interface Data {
+    '@type': '/ethermint.feemarket.v1.Params';
+    no_base_fee: boolean;
+    base_fee_change_denominator: number;
+    elasticity_multiplier: number;
+    enable_height: string;
+    base_fee: string;
+    min_gas_price: string;
+    min_gas_multiplier: string;
+  }
+
+  export type Proto = FeemarketParamsV1_pb;
+}

--- a/src/core/feemarket/v1/msgs/MsgUpdateParams.ts
+++ b/src/core/feemarket/v1/msgs/MsgUpdateParams.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { JSONSerializable } from '../../../../util/json';
+import { AccAddress } from '../../../bech32';
+import { Any } from '@xpla/xpla.proto/google/protobuf/any';
+import { MsgUpdateParams as MsgUpdateFeemarketParamsV1_pb } from '@xpla/xpla.proto/ethermint/feemarket/v1/tx';
+import { FeemarketParamsV1 } from '../Params';
+
+export class MsgUpdateFeemarketParamsV1 extends JSONSerializable<
+  MsgUpdateFeemarketParamsV1.Amino,
+  MsgUpdateFeemarketParamsV1.Data,
+  MsgUpdateFeemarketParamsV1.Proto
+> {
+  /**
+   * @param authority is the address that controls the module
+   * @param params defines the x/bank parameters to update
+   */
+  constructor(
+    public authority: AccAddress,
+    public params: FeemarketParamsV1 | undefined
+  ) {
+    super();
+  }
+
+  public static fromAmino(
+    data: MsgUpdateFeemarketParamsV1.Amino,
+    _isClassic?: boolean
+  ): MsgUpdateFeemarketParamsV1 {
+    const {
+      value: { authority, params },
+    } = data;
+    return new MsgUpdateFeemarketParamsV1(
+      authority,
+      params ? FeemarketParamsV1.fromAmino(params) : undefined
+    );
+  }
+
+  public toAmino(_isClassic?: boolean): MsgUpdateFeemarketParamsV1.Amino {
+    const { authority, params } = this;
+    return {
+      type: 'feemarket/MsgUpdateParams',
+      value: {
+        authority,
+        params: params ? params.toAmino() : undefined,
+      },
+    };
+  }
+
+  public static fromData(
+    data: MsgUpdateFeemarketParamsV1.Data,
+    _isClassic?: boolean
+  ): MsgUpdateFeemarketParamsV1 {
+    const { authority, params } = data;
+    return new MsgUpdateFeemarketParamsV1(
+      authority,
+      params ? FeemarketParamsV1.fromData(params) : undefined
+    );
+  }
+
+  public toData(_isClassic?: boolean): MsgUpdateFeemarketParamsV1.Data {
+    const { authority, params } = this;
+    return {
+      '@type': '/ethermint.feemarket.v1.MsgUpdateParams',
+      authority,
+      params: params ? params.toData() : undefined,
+    };
+  }
+
+  public static fromProto(
+    proto: MsgUpdateFeemarketParamsV1.Proto,
+    _isClassic?: boolean
+  ): MsgUpdateFeemarketParamsV1 {
+    return new MsgUpdateFeemarketParamsV1(
+      proto.authority,
+      proto.params ? FeemarketParamsV1.fromProto(proto.params) : undefined
+    );
+  }
+
+  public toProto(_isClassic?: boolean): MsgUpdateFeemarketParamsV1.Proto {
+    const { authority, params } = this;
+    return MsgUpdateFeemarketParamsV1_pb.fromPartial({
+      authority,
+      params: params ? params.toProto() : undefined,
+    });
+  }
+
+  public packAny(_isClassic?: boolean): Any {
+    return Any.fromPartial({
+      typeUrl: '/ethermint.feemarket.v1.MsgUpdateParams',
+      value: MsgUpdateFeemarketParamsV1_pb.encode(this.toProto()).finish(),
+    });
+  }
+
+  public static unpackAny(
+    msgAny: Any,
+    _isClassic?: boolean
+  ): MsgUpdateFeemarketParamsV1 {
+    return MsgUpdateFeemarketParamsV1.fromProto(
+      MsgUpdateFeemarketParamsV1_pb.decode(msgAny.value)
+    );
+  }
+}
+
+export namespace MsgUpdateFeemarketParamsV1 {
+  export interface Amino {
+    type: 'feemarket/MsgUpdateParams';
+    value: {
+      authority: AccAddress;
+      params: FeemarketParamsV1.Amino | undefined;
+    };
+  }
+
+  export interface Data {
+    '@type': '/ethermint.feemarket.v1.MsgUpdateParams';
+    authority: AccAddress;
+    params: FeemarketParamsV1.Data | undefined;
+  }
+
+  export type Proto = MsgUpdateFeemarketParamsV1_pb;
+}

--- a/src/core/feemarket/v1/msgs/index.ts
+++ b/src/core/feemarket/v1/msgs/index.ts
@@ -1,0 +1,10 @@
+import { MsgUpdateFeemarketParamsV1 } from './MsgUpdateParams';
+
+export * from './MsgUpdateParams';
+
+export type FeemarketMsgV1 = MsgUpdateFeemarketParamsV1;
+export namespace FeemarketMsgV1 {
+  export type Amino = MsgUpdateFeemarketParamsV1.Amino;
+  export type Data = MsgUpdateFeemarketParamsV1.Data;
+  export type Proto = MsgUpdateFeemarketParamsV1.Proto;
+}

--- a/src/core/gov/v1/Vote.ts
+++ b/src/core/gov/v1/Vote.ts
@@ -140,7 +140,7 @@ export class WeightedVoteOptionV1 extends JSONSerializable<
     const { option, weight } = this;
     return {
       option,
-      weight: weight.toString(),
+      weight: weight.toFixed(),
     };
   }
 
@@ -156,7 +156,7 @@ export class WeightedVoteOptionV1 extends JSONSerializable<
     const { option, weight } = this;
     return {
       option,
-      weight: weight.toString(),
+      weight: weight.toFixed(),
     };
   }
 
@@ -164,14 +164,16 @@ export class WeightedVoteOptionV1 extends JSONSerializable<
     proto: WeightedVoteOptionV1.Proto,
     _?: boolean
   ): WeightedVoteOptionV1 {
-    return new WeightedVoteOptionV1(proto.option, proto.weight);
+    const dec18 = new Dec(10).pow(18);
+    return new WeightedVoteOptionV1(proto.option, new Dec(proto.weight).div(dec18));
   }
 
   public toProto(_?: boolean): WeightedVoteOptionV1.Proto {
     const { option, weight } = this;
+    const dec18 = new Dec(10).pow(18);
     return WeightedVoteOptionV1_pb.fromPartial({
       option,
-      weight: weight.toString(),
+      weight: weight.mul(dec18).toFixed(0),
     });
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -41,6 +41,9 @@ export * from './evm';
 export * from './feegrant/msgs';
 export * from './feegrant/allowances';
 
+// Feemarket
+export * from './feemarket';
+
 // Governance
 export * from './gov';
 

--- a/src/core/mint/v1beta1/Params.ts
+++ b/src/core/mint/v1beta1/Params.ts
@@ -132,13 +132,14 @@ export class MintParamsV1B1 extends JSONSerializable<
     proto: MintParamsV1B1.Proto,
     _?: boolean
   ): MintParamsV1B1 {
+    const dec18 = new Dec(10).pow(18);
     return new MintParamsV1B1(
       proto.mintDenom,
-      proto.inflationRateChange,
-      proto.inflationMax,
-      proto.inflationMin,
-      proto.goalBonded,
-      proto.blocksPerYear.toString()
+      new Dec(proto.inflationRateChange).div(dec18),
+      new Dec(proto.inflationMax).div(dec18),
+      new Dec(proto.inflationMin).div(dec18),
+      new Dec(proto.goalBonded).div(dec18),
+      proto.blocksPerYear.toString(),
     );
   }
 
@@ -151,13 +152,14 @@ export class MintParamsV1B1 extends JSONSerializable<
       goal_bonded,
       blocks_per_year,
     } = this;
+    const dec18 = new Dec(10).pow(18);
     return MintParamsV1B1_pb.fromPartial({
       mintDenom: mint_denom,
-      inflationRateChange: inflation_rate_change.toString(),
-      inflationMax: inflation_max.toString(),
-      inflationMin: inflation_min.toString(),
-      goalBonded: goal_bonded.toString(),
-      blocksPerYear: blocks_per_year.toString(),
+      inflationRateChange: inflation_rate_change.mul(dec18).toFixed(0),
+      inflationMax: inflation_max.mul(dec18).toFixed(0),
+      inflationMin: inflation_min.mul(dec18).toFixed(0),
+      goalBonded: goal_bonded.mul(dec18).toFixed(0),
+      blocksPerYear: blocks_per_year.toFixed(0),
     });
   }
 }

--- a/src/core/numeric.ts
+++ b/src/core/numeric.ts
@@ -23,6 +23,9 @@ export namespace Numeric {
     if (value instanceof Dec) {
       return value;
     } else if (typeof value === 'string') {
+      if (value.includes(',')) {
+        value = value.replace(/,/g, '');
+      }
       if (value.includes('.')) {
         return new Dec(value);
       } else {
@@ -36,6 +39,27 @@ export namespace Numeric {
         return new Dec(_value.toString());
       }
     }
+  }
+
+  export function isValidInput(value: Input): boolean {
+    let _value = value.toString();
+    if (_value.startsWith('-') || _value.startsWith('+'))
+      _value = _value.slice(1);
+    if (/^[0-9\,]+(\.[0-9\,]*)?(e[\-\+]?[0-9]+)?$/.test(_value))
+      return true;
+    if (_value.startsWith('0x')) {
+      _value = _value.slice(2);
+      return /^[0-9a-fA-F\,]+(\.[0-9a-fA-F\,]*)?(p[\-\+]?[0-9]+)?$/.test(_value);
+    }
+    if (_value.startsWith('0o')) {
+      _value = _value.slice(2);
+      return /^[0-7\,]+(\.[0-7\,]*)?(p[\-\+]?[0-9]+)?$/.test(_value);
+    }
+    if (_value.startsWith('0b')) {
+      _value = _value.slice(2);
+      return /^[01\,]+(\.[01\,]*)?(p[\-\+]?[0-9]+)?$/.test(_value);
+    }
+    return false;
   }
 }
 
@@ -57,7 +81,15 @@ export namespace Numeric {
 
 export class Dec extends Decimal implements Numeric<Dec> {
   constructor(arg?: Numeric.Input) {
-    super((arg ?? 0).toString());
+    let _arg = (arg ?? 0).toString();
+    if (_arg.includes(',')) {
+      _arg = _arg.replace(/,/g, '');
+    }
+    super(_arg);
+  }
+
+  public static isValidInput(arg: Numeric.Input): boolean {
+    return Numeric.isValidInput(arg);
   }
 
   public toString(): string {
@@ -123,8 +155,19 @@ const _Int = Decimal.clone();
  */
 export class Int extends _Int implements Numeric<Numeric.Output> {
   constructor(arg?: Numeric.Input) {
-    const _arg = new Decimal((arg ?? 0).toString());
-    super(_arg.divToInt(1));
+    let _arg = (arg ?? 0).toString();
+    if (_arg.includes(',')) {
+      _arg = _arg.replace(/,/g, '');
+    }
+    super((new Decimal(_arg)).divToInt(1));
+  }
+
+  public static isValidInput(arg: Numeric.Input): boolean {
+    if (Numeric.isValidInput(arg)) {
+      const _dec = Numeric.parse(arg);
+      return _dec.isInteger();
+    }
+    return false;
   }
 
   public toString(): string {

--- a/src/core/slashing/v1beta1/Params.ts
+++ b/src/core/slashing/v1beta1/Params.ts
@@ -126,14 +126,15 @@ export class SlashingParamsV1B1 extends JSONSerializable<
     proto: SlashingParamsV1B1.Proto,
     _?: boolean
   ): SlashingParamsV1B1 {
+    const dec18 = new Dec(10).pow(18);
     return new SlashingParamsV1B1(
       proto.signedBlocksWindow.toString(),
-      Buffer.from(proto.minSignedPerWindow).toString('ascii'),
+      new Dec(Buffer.from(proto.minSignedPerWindow).toString('ascii')).div(dec18),
       proto.downtimeJailDuration
         ? Duration.fromProto(proto.downtimeJailDuration)
         : undefined,
-      Buffer.from(proto.slashFractionDoubleSign).toString('ascii'),
-      Buffer.from(proto.slashFractionDowntime).toString('ascii')
+      new Dec(Buffer.from(proto.slashFractionDoubleSign).toString('ascii')).div(dec18),
+      new Dec(Buffer.from(proto.slashFractionDowntime).toString('ascii')).div(dec18),
     );
   }
 
@@ -145,18 +146,19 @@ export class SlashingParamsV1B1 extends JSONSerializable<
       slash_fraction_double_sign,
       slash_fraction_downtime,
     } = this;
+    const dec18 = new Dec(10).pow(18);
     return SlashingParamsV1B1_pb.fromPartial({
       signedBlocksWindow: signed_blocks_window.toFixed(),
-      minSignedPerWindow: Buffer.from(min_signed_per_window.toFixed(), 'ascii'),
+      minSignedPerWindow: Buffer.from(min_signed_per_window.mul(dec18).toFixed(0), 'ascii'),
       downtimeJailDuration: downtime_jail_duration
         ? downtime_jail_duration.toProto()
         : undefined,
       slashFractionDoubleSign: Buffer.from(
-        slash_fraction_double_sign.toFixed(),
+        slash_fraction_double_sign.mul(dec18).toFixed(0),
         'ascii'
       ),
       slashFractionDowntime: Buffer.from(
-        slash_fraction_downtime.toFixed(),
+        slash_fraction_downtime.mul(dec18).toFixed(0),
         'ascii'
       ),
     });

--- a/src/core/staking/v1beta1/Params.ts
+++ b/src/core/staking/v1beta1/Params.ts
@@ -24,7 +24,7 @@ export class StakingParamsV1B1 extends JSONSerializable<
     public max_entries: number,
     public historical_entries: number,
     public bond_denom: Denom,
-    min_commission_rate: Numeric.Input
+    min_commission_rate: Numeric.Input,
   ) {
     super();
     this.min_commission_rate = new Dec(min_commission_rate);
@@ -123,13 +123,14 @@ export class StakingParamsV1B1 extends JSONSerializable<
     proto: StakingParamsV1B1.Proto,
     _?: boolean
   ): StakingParamsV1B1 {
+    const dec18 = new Dec(10).pow(18);
     return new StakingParamsV1B1(
       proto.unbondingTime ? Duration.fromProto(proto.unbondingTime) : undefined,
       proto.maxValidators,
       proto.maxEntries,
       proto.historicalEntries,
       proto.bondDenom,
-      proto.minCommissionRate
+      new Dec(proto.minCommissionRate).div(dec18),
     );
   }
 
@@ -142,13 +143,14 @@ export class StakingParamsV1B1 extends JSONSerializable<
       bond_denom,
       min_commission_rate,
     } = this;
+    const dec18 = new Dec(10).pow(18);
     return StakingParamsV1B1_pb.fromPartial({
       unbondingTime: unbonding_time ? unbonding_time.toProto() : undefined,
       maxValidators: max_validators,
       maxEntries: max_entries,
       historicalEntries: historical_entries,
       bondDenom: bond_denom,
-      minCommissionRate: min_commission_rate.toFixed(),
+      minCommissionRate: min_commission_rate.mul(dec18).toFixed(0),
     });
   }
 }

--- a/src/core/xpla/v1beta1/Params.ts
+++ b/src/core/xpla/v1beta1/Params.ts
@@ -118,12 +118,13 @@ export class RewardParamsV1B1 extends JSONSerializable<
     proto: RewardParamsV1B1.Proto,
     _?: boolean
   ): RewardParamsV1B1 {
+    const dec18 = new Dec(10).pow(18);
     return new RewardParamsV1B1(
-      proto.feePoolRate,
-      proto.communityPoolRate,
-      proto.reserveRate,
+      new Dec(proto.feePoolRate).div(dec18),
+      new Dec(proto.communityPoolRate).div(dec18),
+      new Dec(proto.reserveRate).div(dec18),
       proto.reserveAccount,
-      proto.rewardDistributeAccount
+      proto.rewardDistributeAccount,
     );
   }
 
@@ -135,10 +136,11 @@ export class RewardParamsV1B1 extends JSONSerializable<
       reserve_account,
       reward_distribute_account,
     } = this;
+    const dec18 = new Dec(10).pow(18);
     return RewardParamsV1B1_pb.fromPartial({
-      feePoolRate: fee_pool_rate.toFixed(),
-      communityPoolRate: community_pool_rate.toFixed(),
-      reserveRate: reserve_rate.toFixed(),
+      feePoolRate: fee_pool_rate.mul(dec18).toFixed(0),
+      communityPoolRate: community_pool_rate.mul(dec18).toFixed(0),
+      reserveRate: reserve_rate.mul(dec18).toFixed(0),
       reserveAccount: reserve_account,
       rewardDistributeAccount: reward_distribute_account,
     });


### PR DESCRIPTION
Modified **TxAPI**'s `estimateGas` result to return an integer by rounding up, instead of a floating-point number with decimals.

Added the following queries to **BankAPI**:
  - `balanceByDenom`
  - `denomOwners`
  - `denomsMetadata`

Added messages and APIs for the **feemarket** module.

Fixed an issue where certain properties (related to `cosmos-sdk/types.Dec`) in the following messages were not being encoded in `tx_bytes`:
  - `MsgCreateValidatorV1B1`
  - `MsgEditValidatorV1B1`
  - `MsgUpdateDistributionParamsV1B1`
  - `MsgUpdateFeemarketParamsV1`
  - `MsgUpdateMintParamsV1B1`
  - `MsgUpdateRewardParamsV1B1`
  - `MsgUpdateSlashingParamsV1B1`
  - `MsgUpdateStakingParamsV1B1`
  - `MsgVoteWeightedV1`

In **LCDClient**, `getGasPrices()`, which reads the `gasPrices` from the current LCD configuration, has been renamed to `gasPrices(...)` and now includes functionality for modifying its value.

**LCDClient**'s `getGasPrices()` has been updated to retrieve `min_gas_price` from the LCD’s module settings.

Added `gasAdjustment(...)` in **LCDClient**, allowing reading and modifying of the current `gasAdjustment` in the LCD configuration.
