### PR TITLE
feat: v1.7.0-beta.3

### DIFF
--- a/src/client/ecd/api/TokenAPI.ts
+++ b/src/client/ecd/api/TokenAPI.ts
@@ -113,13 +113,29 @@ export class EvmTokenAPI extends EvmAPI {
     contract: EvmAddress,
     address: EvmAddress
   ): Promise<[Coins, Pagination]> {
+    const decimals = await this.decimals(contract);
     const symbol = await this.symbol(contract);
     const amount = await this.balanceOf(contract, address);
+    let denom = '_';
+    switch (decimals) {
+      case 24: denom = 'y'; break;
+      case 21: denom = 'z'; break;
+      case 18: denom = 'a'; break;
+      case 15: denom = 'f'; break;
+      case 12: denom = 'p'; break;
+      case 9: denom = 'n'; break;
+      case 6: denom = 'u'; break;
+      case 3: denom = 'm'; break;
+      case 2: denom = 'c'; break;
+      case 1: denom = 'd'; break;
+      case 0: denom = ''; break;
+    }
+    denom += symbol.toLowerCase();
     return [
       Coins.fromData([
         {
-          denom: symbol,
-          amount: amount.toString(),
+          denom,
+          amount: amount.toFixed(),
         },
       ]),
       { next_key: null, total: 0 },


### PR DESCRIPTION
### xpla.js 1.7.0-beta.3 Changes

Added the `bufferToHex()` method to `ECDClient`.

To work around the issue where `toString('hex')` doesn't work properly when `Buffer` is `subarray`ed in the web browser,
Replaced the `toString` calls with `bufferToHex` in the parts where `subarray` is used.

Modified the `TokenAPI` in `ECDClient` to display the `denom` of `Coins` in the result of the `balance()` query with an SI Prefix attached, using the lowercase symbol based on the decimals of the ERC20 token.
