### PR TITLE
fix: TxSearchOptions add limit

### DIFF
--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -196,6 +196,7 @@ export interface TxSearchOptions extends PaginationOptions {
   events: { key: string; value: string }[];
   // post v0.47.x
   query: string;
+  limit?: number;
 }
 
 export class TxAPI extends BaseAPI {


### PR DESCRIPTION
Hello.

There is no limit option in TxSearchOptions, so I can't give a limit. 
I've added that option.

reference
https://docs.cosmos.network/api#tag/Service/operation/GetTxsEvent